### PR TITLE
Add Playwright script for Yahoo sign up

### DIFF
--- a/create-yahoo-account.js
+++ b/create-yahoo-account.js
@@ -1,0 +1,28 @@
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Open Yahoo sign up page
+  await page.goto('https://login.yahoo.com/account/create');
+
+  // Fill out the sign up form (replace with your details)
+  await page.fill('input[name="firstName"]', 'John');
+  await page.fill('input[name="lastName"]', 'Doe');
+  await page.fill('input[name="yid"]', 'john.doe.test');
+  await page.fill('input[name="password"]', 'ExamplePassword123');
+  await page.fill('input[name="phone"]', '1234567890');
+  await page.fill('input[name="mm"]', '1');
+  await page.fill('input[name="dd"]', '1');
+  await page.fill('input[name="yyyy"]', '1990');
+
+  // Submit the form
+  await page.click('button[type="submit"]');
+
+  // Wait for some selector that indicates success or additional steps
+  await page.waitForTimeout(5000);
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- Add `create-yahoo-account.js` with Playwright example to open Yahoo sign-up page and fill the form

## Testing
- `node create-yahoo-account.js` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c44a7ee208327a28a2067a718dc89