### PR TITLE
Implement custom Next.js auth with Postgres sessions

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,0 +1,80 @@
+'use server'
+import bcrypt from 'bcrypt'
+import { SignupSchema, LoginSchema, FormState } from '../lib/definitions'
+import { db } from '../lib/db'
+import { createSession, deleteSession, getSession } from '../lib/session'
+import { redirect } from 'next/navigation'
+
+export async function signup(state: FormState, formData: FormData): Promise<FormState> {
+  const parsed = SignupSchema.safeParse(Object.fromEntries(formData))
+  if (!parsed.success) {
+    return { message: 'Invalid input' }
+  }
+  const { firstName, lastName, company, email, password } = parsed.data
+  const hash = await bcrypt.hash(password, 10)
+  const { rows } = await db.query(
+    `WITH c AS (
+      INSERT INTO companies (name) VALUES ($1)
+      ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+      RETURNING id
+    )
+    INSERT INTO users (first_name, last_name, company_id, email, password, role)
+    VALUES ($2, $3, (SELECT id FROM c), $4, $5, 'owner')
+    RETURNING id`,
+    [company, firstName, lastName, email, hash]
+  )
+  const user = rows[0]
+  if (!user) return { message: 'Signup failed' }
+  await createSession(user.id)
+  redirect('/dashboard')
+}
+
+export async function login(state: FormState, formData: FormData): Promise<FormState> {
+  const parsed = LoginSchema.safeParse(Object.fromEntries(formData))
+  if (!parsed.success) return { message: 'Invalid input' }
+  const { email, password } = parsed.data
+  const { rows } = await db.query('SELECT id, password FROM users WHERE email=$1', [email])
+  const user = rows[0]
+  if (!user) return { message: 'Invalid credentials' }
+  const valid = await bcrypt.compare(password, user.password)
+  if (!valid) return { message: 'Invalid credentials' }
+  await createSession(user.id)
+  redirect('/dashboard')
+}
+
+export async function logout() {
+  const session = await getSession()
+  if (session) {
+    await deleteSession(session.id)
+  }
+  redirect('/login')
+}
+
+export async function createUser(state: FormState, formData: FormData): Promise<FormState> {
+  const session = await getSession()
+  if (!session) return { message: 'Unauthorized' }
+  const { rows: ownerRows } = await db.query('SELECT role, company_id FROM users WHERE id=$1', [session.userId])
+  const owner = ownerRows[0]
+  if (!owner || owner.role !== 'owner') return { message: 'Forbidden' }
+  const parsed = SignupSchema.safeParse(Object.fromEntries(formData))
+  if (!parsed.success) return { message: 'Invalid input' }
+  const { firstName, lastName, company, email, password } = parsed.data
+  const hash = await bcrypt.hash(password, 10)
+  const { rows } = await db.query(
+    'INSERT INTO users (first_name, last_name, company_id, email, password, role) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id',
+    [firstName, lastName, owner.company_id, email, hash, formData.get('role') || 'member']
+  )
+  const user = rows[0]
+  if (!user) return { message: 'Failed to create user' }
+  return { message: 'User created' }
+}
+
+export async function getUsers() {
+  const session = await getSession()
+  if (!session) return []
+  const { rows } = await db.query(
+    'SELECT id, first_name, last_name, role FROM users WHERE company_id = (SELECT company_id FROM users WHERE id = $1)',
+    [session.userId]
+  )
+  return rows
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import { UserList } from '../ui/user-list'
+
+export default async function DashboardPage() {
+  return (
+    <main>
+      <h1 className="text-xl font-bold mb-4">Manage Users</h1>
+      <UserList />
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="p-4">{children}</body>
+    </html>
+  )
+}

--- a/app/lib/dal.ts
+++ b/app/lib/dal.ts
@@ -1,0 +1,18 @@
+import 'server-only'
+import { cache } from 'react'
+import { cookies } from 'next/headers'
+import { decrypt } from './session'
+import { db } from './db'
+
+export const verifySession = cache(async () => {
+  const token = cookies().get('session')?.value
+  if (!token) {
+    return null
+  }
+  const payload = await decrypt(token)
+  if (!payload) return null
+  const { rows } = await db.query('SELECT user_id FROM sessions WHERE id = $1', [payload.sessionId])
+  const session = rows[0]
+  if (!session) return null
+  return { userId: session.user_id as string }
+})

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,0 +1,5 @@
+import { Pool } from 'pg'
+
+const connectionString = process.env.DATABASE_URL
+
+export const db = new Pool({ connectionString })

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const SignupSchema = z.object({
+  firstName: z.string().min(2),
+  lastName: z.string().min(2),
+  company: z.string().min(2),
+  email: z.string().email(),
+  password: z.string().min(8)
+})
+
+export const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8)
+})
+
+export type FormState = { message?: string } | undefined
+
+export interface SessionPayload {
+  sessionId: string
+  expiresAt: Date
+}

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -1,0 +1,59 @@
+import 'server-only'
+import { SignJWT, jwtVerify } from 'jose'
+import { cookies } from 'next/headers'
+import { db } from './db'
+import { SessionPayload } from './definitions'
+
+const secretKey = process.env.SESSION_SECRET as string
+const encodedKey = new TextEncoder().encode(secretKey)
+
+export async function encrypt(payload: SessionPayload) {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('7d')
+    .sign(encodedKey)
+}
+
+export async function decrypt(session: string | undefined = ''): Promise<SessionPayload | null> {
+  try {
+    const { payload } = await jwtVerify(session, encodedKey, { algorithms: ['HS256'] })
+    return payload as SessionPayload
+  } catch (e) {
+    return null
+  }
+}
+
+export async function createSession(userId: string) {
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+  const { rows } = await db.query(
+    'INSERT INTO sessions (user_id, expires_at) VALUES ($1,$2) RETURNING id',
+    [userId, expiresAt]
+  )
+  const sessionId = rows[0].id as string
+  const token = await encrypt({ sessionId, expiresAt })
+  const cookieStore = cookies()
+  cookieStore.set('session', token, {
+    httpOnly: true,
+    secure: true,
+    expires: expiresAt,
+    sameSite: 'lax',
+    path: '/',
+  })
+}
+
+export async function deleteSession(sessionId: string) {
+  await db.query('DELETE FROM sessions WHERE id = $1', [sessionId])
+  cookies().delete('session')
+}
+
+export async function getSession() {
+  const token = cookies().get('session')?.value
+  if (!token) return null
+  const payload = await decrypt(token)
+  if (!payload) return null
+  const { rows } = await db.query('SELECT id, user_id FROM sessions WHERE id = $1', [payload.sessionId])
+  const session = rows[0]
+  if (!session) return null
+  return { id: session.id as string, userId: session.user_id as string }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from '../ui/login-form'
+
+export default function LoginPage() {
+  return (
+    <main>
+      <LoginForm />
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main className="space-y-4">
+      <h1 className="text-xl font-bold">Welcome</h1>
+      <div className="space-x-4">
+        <Link href="/signup">Sign Up</Link>
+        <Link href="/login">Login</Link>
+      </div>
+    </main>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,9 @@
+import { SignupForm } from '../ui/signup-form'
+
+export default function SignupPage() {
+  return (
+    <main>
+      <SignupForm />
+    </main>
+  )
+}

--- a/app/ui/login-form.tsx
+++ b/app/ui/login-form.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useActionState } from 'react'
+import { login } from '../actions/auth'
+
+export function LoginForm() {
+  const [state, action, pending] = useActionState(login, undefined)
+
+  return (
+    <form action={action} className="space-y-4 max-w-md">
+      <div>
+        <label htmlFor="email">Email</label>
+        <input id="email" name="email" type="email" className="border" />
+      </div>
+      <div>
+        <label htmlFor="password">Password</label>
+        <input id="password" name="password" type="password" className="border" />
+      </div>
+      {state?.message && <p className="text-red-500">{state.message}</p>}
+      <button type="submit" disabled={pending}>Login</button>
+    </form>
+  )
+}

--- a/app/ui/signup-form.tsx
+++ b/app/ui/signup-form.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useActionState } from 'react'
+import { signup } from '../actions/auth'
+
+export function SignupForm() {
+  const [state, action, pending] = useActionState(signup, undefined)
+
+  return (
+    <form action={action} className="space-y-4 max-w-md">
+      <div>
+        <label htmlFor="firstName">First Name</label>
+        <input id="firstName" name="firstName" className="border" />
+      </div>
+      <div>
+        <label htmlFor="lastName">Last Name</label>
+        <input id="lastName" name="lastName" className="border" />
+      </div>
+      <div>
+        <label htmlFor="company">Company</label>
+        <input id="company" name="company" className="border" />
+      </div>
+      <div>
+        <label htmlFor="email">Email</label>
+        <input id="email" name="email" type="email" className="border" />
+      </div>
+      <div>
+        <label htmlFor="password">Password</label>
+        <input id="password" name="password" type="password" className="border" />
+      </div>
+      {state?.message && <p className="text-red-500">{state.message}</p>}
+      <button type="submit" disabled={pending}>Sign Up</button>
+    </form>
+  )
+}

--- a/app/ui/user-list.tsx
+++ b/app/ui/user-list.tsx
@@ -1,0 +1,16 @@
+import { getUsers } from '../actions/auth'
+
+export async function UserList() {
+  const users = await getUsers()
+  return (
+    <div className="space-y-2">
+      {users.map(u => (
+        <div key={u.id} className="border p-2 rounded">
+          <p>
+            {u.first_name} {u.last_name} - {u.role}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,20 +1,28 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
 CREATE TABLE IF NOT EXISTS companies (
-  id SERIAL PRIMARY KEY,
-  name TEXT UNIQUE NOT NULL
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS users (
-  id SERIAL PRIMARY KEY,
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   first_name TEXT NOT NULL,
   last_name TEXT NOT NULL,
-  company_id INTEGER REFERENCES companies(id),
+  company_id UUID REFERENCES companies(id),
   email TEXT UNIQUE NOT NULL,
   password TEXT NOT NULL,
-  role TEXT NOT NULL
+  role TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER REFERENCES users(id),
-  expires_at TIMESTAMP NOT NULL
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- implement basic Next.js pages for signup/login/dashboard
- add UI components using Server/Client actions
- create database connection and session helpers
- implement server actions for signup/login/logout and user management
- update schema for UUID ids and timestamp columns

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef1defc9c83279f74b93f18ad73af